### PR TITLE
chore: add support of ESP32S3 Super Mini board

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -53,7 +53,6 @@ build_flags =
 [env:firmware_esp32s3]
 extends = env:firmware
 board = esp32-s3-devkitc-1
-monitor_speed = 115200
 board_build.flash_size = 4MB
 board_build.flash_mode = dio
 board_upload.flash_size = 4MB
@@ -62,7 +61,6 @@ board_build.partitions = custom_4MB.csv
 [env:firmware_esp32s3_matrix]
 extends = env:firmware
 board = lolin_s3_mini
-monitor_speed = 115200
 board_build.flash_size = 4MB
 board_build.flash_mode = dio
 board_build.partitions = custom_4MB.csv

--- a/platformio.ini
+++ b/platformio.ini
@@ -54,9 +54,6 @@ build_flags =
 extends = env:firmware
 board = esp32-s3-devkitc-1
 monitor_speed = 115200
-
-[env:firmware_esp32s3_4mb]
-extends = env:firmware_esp32s3
 board_build.flash_size = 4MB
 board_build.flash_mode = dio
 board_upload.flash_size = 4MB

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,7 +23,7 @@ lib_deps =
     wollewald/BH1750_WE@1.1.10
 	dfrobot/DFRobot_DF1201S@^1.0.2
     mathertel/OneButton@2.6.2
-build_flags = 
+build_flags =
     -D ARDUINO_ESP32_DEV
     -D BME280_ENABLED
 	-D SHT2X_ENABLED
@@ -36,23 +36,27 @@ build_flags =
     -D CONFIG_ASYNC_TCP_MAX_ACK_TIME=5000 # (keep default)
     -D CONFIG_ASYNC_TCP_PRIORITY=10 # (keep default)
     -D CONFIG_ASYNC_TCP_QUEUE_SIZE=64 # (keep default)
-    -D CONFIG_ASYNC_TCP_RUNNING_CORE=1 
+    -D CONFIG_ASYNC_TCP_RUNNING_CORE=1
 
 [env:test_animation]
 extends = env:firmware
-build_flags = 
+build_flags =
     ${env:firmware.build_flags}
     -D TEST_ANIMATION
 
 [env:test_min_of_silence]
 extends = env:firmware
-build_flags = 
+build_flags =
     ${env:firmware.build_flags}
     -D TEST_MIN_OF_SILENCE
 
 [env:firmware_esp32s3]
 extends = env:firmware
 board = esp32-s3-devkitc-1
+board_build.flash_size = 4MB
+board_build.flash_mode = dio
+board_upload.flash_size = 4MB
+board_build.partitions = custom_4MB.csv
 
 [env:firmware_esp32s3_matrix]
 extends = env:firmware

--- a/platformio.ini
+++ b/platformio.ini
@@ -53,6 +53,10 @@ build_flags =
 [env:firmware_esp32s3]
 extends = env:firmware
 board = esp32-s3-devkitc-1
+monitor_speed = 115200
+
+[env:firmware_esp32s3_4mb]
+extends = env:firmware_esp32s3
 board_build.flash_size = 4MB
 board_build.flash_mode = dio
 board_upload.flash_size = 4MB


### PR DESCRIPTION
[ESP32S3 Super Mini](https://www.espboards.dev/esp32/esp32-s3-super-mini/) and other cheap S3 boards are equipped with 4M of RAM, and the current setting of `platformio.ini` is configured for esp32-s3-devkitc-1 with 8MB of flash.

With this change, a range of supported boards is extended as it will support both 4M and 8M versions.

Tested with my own esp32-s3-super-mini

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Оновлено конфігурацію проекту для плат ESP32‑S3: додано окремі середовища для двох варіантів плати із встановленими параметрами флешу, розділів та стандартною швидкістю монітора.
  * Зроблено незначні форматувальні правки в налаштуваннях збірки (без змін функціональних значень прапорів).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->