### PR TITLE
Startup flag

### DIFF
--- a/src/JaamFusion.cpp
+++ b/src/JaamFusion.cpp
@@ -399,8 +399,8 @@ void playMelody(SoundType type) {
 
 bool needToPlaySound(SoundType type) {
 #if BUZZER_ENABLED || DFPLAYER_PRO_ENABLED
-  // do not play any sound before websocket connection
-  if (startup) return false;
+  // do not play any sound before websocket connection and startup
+  if (startup || !isFirstDataFetchCompleted) return false;
 
   // ignore mute on alert
   //if (SoundType::ALERT_ON == type && settings.getBool(SOUND_ON_ALERT) && settings.getBool(IGNORE_MUTE_ON_ALERT)) return true;

--- a/src/JaamFusion.cpp
+++ b/src/JaamFusion.cpp
@@ -122,6 +122,7 @@ bool                wifiConnected = false;
 WebsocketsClient    websocket;
 time_t              websocketLastPingTime = 0;
 bool                isFirstDataFetchCompleted = false;
+bool                startup = true;
 bool                websocketConnected;
 bool                websocketReconnect = false;
 time_t              lastWebsocketConnectTime = 0;
@@ -261,7 +262,7 @@ bool isItNightNow() {
 }
 
 int getCurrentMapMode() {
-  if (minuteOfSilence || uaAnthemPlaying || !isFirstDataFetchCompleted) return MapModes::FLAG; // ua flag
+  if (minuteOfSilence || uaAnthemPlaying || startup) return MapModes::FLAG; // ua flag
 
 //   int homeRegionId = settings.getInt(HOME_DISTRICT);
 //   int alarmMode = settings.getInt(ALARMS_AUTO_SWITCH);
@@ -399,7 +400,7 @@ void playMelody(SoundType type) {
 bool needToPlaySound(SoundType type) {
 #if BUZZER_ENABLED || DFPLAYER_PRO_ENABLED
   // do not play any sound before websocket connection
-  if (!isFirstDataFetchCompleted) return false;
+  if (startup) return false;
 
   // ignore mute on alert
   //if (SoundType::ALERT_ON == type && settings.getBool(SOUND_ON_ALERT) && settings.getBool(IGNORE_MUTE_ON_ALERT)) return true;
@@ -1287,6 +1288,7 @@ void onMessageCallback(WebsocketsMessage msg) {
             updateSirenIfNeeded(alertBit);
         }
         isFirstDataFetchCompleted = true;
+        startup = false;
         alertsHash = actualHash;
     }
 


### PR DESCRIPTION
додано окрему змінну startup для відокремлення прапорця "перше завантаження" і "завантаження після реконнекта"
дозволяє уникнути повторних анімацій тривог і блимання прапора (бо у прапора була умова показуватись при "першому завантаженні") при реконекті вебсокета
startup ініціюється в true і постійно ставиться в false при отриманні даних тривог з вебсокета і ніколи примусово не повертається в true, забезпечуючи цим показ прапора на отриманні даних один раз на старті  

isFirstDataFetchCompleted може скидуватись в false при примусовому реконекті до вебсокета і цьому випадку треба скіпати анімаціі, що і відбувається при значенні false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примітки до випуску

* **Вдосконалення**
  * Оптимізовано поведінку програми на етапі запуску з покращеним управлінням ініціалізацією карти та відтворенням звуку.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->