### PR TITLE
Remove esp32s3_matrix

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -25,7 +25,7 @@ lib_deps =
 	dfrobot/DFRobot_DF1201S@^1.0.2
     mathertel/OneButton@2.6.2
     tobozo/ESP32-targz@1.3.1
-build_flags = 
+build_flags =
     -D BME280_ENABLED
 	-D SHT2X_ENABLED
 	-D SHT3X_ENABLED
@@ -67,13 +67,6 @@ board = esp32-s3-devkitc-1
 board_build.flash_size = 4MB
 board_build.flash_mode = dio
 board_upload.flash_size = 4MB
-board_build.partitions = custom_4MB.csv
-
-[env:firmware_esp32s3_matrix]
-extends = env:firmware
-board = lolin_s3_mini
-board_build.flash_size = 4MB
-board_build.flash_mode = dio
 board_build.partitions = custom_4MB.csv
 
 [env:firmware_esp32c3]


### PR DESCRIPTION
This pull request makes a small change to the `platformio.ini` configuration file by removing the `[env:firmware_esp32s3_matrix]` environment definition. This streamlines the configuration by eliminating an unused or deprecated build environment.

Waveshare ESP32-S3-Matrix is supported by the default firmware_esp32s3 and is not a reason to keep a separate config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Видалена конфігурація середовища firmware_esp32s3_matrix з файлу конфігурації проекту.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->