### PR TITLE
feat: captive portal timeout + WiFi behavior matching old WiFiManager

### DIFF
--- a/src/JaamFusion.cpp
+++ b/src/JaamFusion.cpp
@@ -3452,6 +3452,7 @@ void setup() {
     wifi.setOnNetworkSaved([](const String& ssid) {
         display.showServiceMessage(ssid, "WiFi AP збережено:");
     });
+    wifi.setOnReboot([]() { requestRebootDevice(); });
 
     display.showServiceMessage("підключення...", "WiFi");
     servicePin(WIFI);

--- a/src/JaamFusion.cpp
+++ b/src/JaamFusion.cpp
@@ -3452,7 +3452,7 @@ void setup() {
     wifi.setOnNetworkSaved([](const String& ssid) {
         display.showServiceMessage(ssid, "WiFi AP збережено:");
     });
-    wifi.setOnReboot([]() { requestRebootDevice(); });
+    wifi.setOnReboot([](uint32_t ms) { rebootDevice(ms); });
 
     display.showServiceMessage("підключення...", "WiFi");
     servicePin(WIFI);

--- a/src/JaamWifi.cpp
+++ b/src/JaamWifi.cpp
@@ -38,6 +38,7 @@ void JaamWifi::process() {
         dnsServer.processNextRequest();
         portalServer.handleClient();
         if (millis() - portalStartTime >= PORTAL_TIMEOUT) {
+            portalStartTime = millis();
             LOG.printf("[WIFI] Captive portal timeout, rebooting...\n");
             if (onRebootCb) onRebootCb(5000);
         }

--- a/src/JaamWifi.cpp
+++ b/src/JaamWifi.cpp
@@ -39,7 +39,7 @@ void JaamWifi::process() {
         portalServer.handleClient();
         if (millis() - portalStartTime >= PORTAL_TIMEOUT) {
             LOG.printf("[WIFI] Captive portal timeout, rebooting...\n");
-            if (onRebootCb) onRebootCb();
+            if (onRebootCb) onRebootCb(5000);
         }
         return;
     }
@@ -59,10 +59,14 @@ void JaamWifi::process() {
     reconnectAttempts++;
     if (reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
         LOG.printf("[WIFI] Reconnect attempt %d/%d\n", reconnectAttempts, MAX_RECONNECT_ATTEMPTS);
+        WiFi.disconnect(true);
+        WiFi.mode(WIFI_OFF);
+        delay(100);
+        WiFi.mode(WIFI_STA);
         tryMultiConnect(MULTI_RECONNECT_TIMEOUT);
     } else {
         LOG.printf("[WIFI] Max reconnect attempts reached, rebooting...\n");
-        if (onRebootCb) onRebootCb();
+        if (onRebootCb) onRebootCb(3000);
     }
 }
 
@@ -348,7 +352,7 @@ void JaamWifi::openCaptivePortal() {
         portalServer.send(200, "text/html", html);
 
         delay(2000);
-        if (onRebootCb) onRebootCb();
+        if (onRebootCb) onRebootCb(2000);
     });
 
     portalServer.onNotFound([this]() {

--- a/src/JaamWifi.cpp
+++ b/src/JaamWifi.cpp
@@ -37,6 +37,10 @@ void JaamWifi::process() {
     if (portalActive) {
         dnsServer.processNextRequest();
         portalServer.handleClient();
+        if (millis() - portalStartTime >= PORTAL_TIMEOUT) {
+            LOG.printf("[WIFI] Captive portal timeout, rebooting...\n");
+            if (onRebootCb) onRebootCb();
+        }
         return;
     }
 
@@ -58,7 +62,7 @@ void JaamWifi::process() {
         tryMultiConnect(MULTI_RECONNECT_TIMEOUT);
     } else {
         LOG.printf("[WIFI] Max reconnect attempts reached, rebooting...\n");
-        ESP.restart();
+        if (onRebootCb) onRebootCb();
     }
 }
 
@@ -344,7 +348,7 @@ void JaamWifi::openCaptivePortal() {
         portalServer.send(200, "text/html", html);
 
         delay(2000);
-        ESP.restart();
+        if (onRebootCb) onRebootCb();
     });
 
     portalServer.onNotFound([this]() {
@@ -354,6 +358,7 @@ void JaamWifi::openCaptivePortal() {
 
     portalServer.begin();
     portalActive = true;
+    portalStartTime = millis();
 
     if (onPortalStartedCb) onPortalStartedCb(String(apName));
 }

--- a/src/JaamWifi.h
+++ b/src/JaamWifi.h
@@ -68,8 +68,8 @@ private:
 
     static const uint8_t  MAX_NETWORKS            = 5;
     static const uint8_t  MAX_RECONNECT_ATTEMPTS  = 5;
-    static const uint32_t MULTI_CONNECT_TIMEOUT   = 15000; // ms при першому start
-    static const uint32_t MULTI_RECONNECT_TIMEOUT = 5000;  // ms при reconnect
+    static const uint32_t MULTI_CONNECT_TIMEOUT   = 30000; // ms при першому start
+    static const uint32_t MULTI_RECONNECT_TIMEOUT = 30000; // ms при reconnect
     static const uint32_t PORTAL_TIMEOUT          = 180000; // 3 хв
 
     StringCb onConnectedCb;

--- a/src/JaamWifi.h
+++ b/src/JaamWifi.h
@@ -29,6 +29,7 @@ public:
     void setOnPortalStarted(StrCb cb)    { onPortalStartedCb = cb; }    // (apSsid)
     void setOnClientConnected(StrCb cb)  { onClientConnectedCb = cb; }  // (ip)
     void setOnNetworkSaved(StrCb cb)     { onNetworkSavedCb = cb; }     // (ssid)
+    void setOnReboot(VoidCb cb)          { onRebootCb = cb; }
 
     // --- Lifecycle ---
     void begin(const char* chipId);  // блокуючий: підключення або відкриття порталу
@@ -61,6 +62,7 @@ private:
     bool          connected      = false;
     bool          portalActive   = false;
     unsigned long connectTime    = 0;
+    unsigned long portalStartTime = 0;
     uint8_t       reconnectAttempts = 0;
     char          apName[32]     = {};
 
@@ -68,12 +70,14 @@ private:
     static const uint8_t  MAX_RECONNECT_ATTEMPTS  = 5;
     static const uint32_t MULTI_CONNECT_TIMEOUT   = 15000; // ms при першому start
     static const uint32_t MULTI_RECONNECT_TIMEOUT = 5000;  // ms при reconnect
+    static const uint32_t PORTAL_TIMEOUT          = 180000; // 3 хв
 
     StringCb onConnectedCb;
     VoidCb   onDisconnectedCb;
     StrCb    onPortalStartedCb;
     StrCb    onClientConnectedCb;
     StrCb    onNetworkSavedCb;
+    VoidCb   onRebootCb;
 
     void loadNetworksIntoMulti();
     void migrateFromWifiManager();

--- a/src/JaamWifi.h
+++ b/src/JaamWifi.h
@@ -16,9 +16,10 @@ struct SavedNetwork {
 
 class JaamWifi {
 public:
-    using StringCb = std::function<void(const String&, const String&)>; // (a, b)
-    using StrCb    = std::function<void(const String&)>;               // (a)
-    using VoidCb   = std::function<void()>;
+    using StringCb  = std::function<void(const String&, const String&)>; // (a, b)
+    using StrCb     = std::function<void(const String&)>;               // (a)
+    using VoidCb    = std::function<void()>;
+    using RebootCb  = std::function<void(uint32_t)>;                    // (delayMs)
 
     // --- Dependency injection ---
     void setSettings(JaamSettings* s) { settings = s; }
@@ -29,7 +30,7 @@ public:
     void setOnPortalStarted(StrCb cb)    { onPortalStartedCb = cb; }    // (apSsid)
     void setOnClientConnected(StrCb cb)  { onClientConnectedCb = cb; }  // (ip)
     void setOnNetworkSaved(StrCb cb)     { onNetworkSavedCb = cb; }     // (ssid)
-    void setOnReboot(VoidCb cb)          { onRebootCb = cb; }
+    void setOnReboot(RebootCb cb)        { onRebootCb = cb; }
 
     // --- Lifecycle ---
     void begin(const char* chipId);  // блокуючий: підключення або відкриття порталу
@@ -77,7 +78,7 @@ private:
     StrCb    onPortalStartedCb;
     StrCb    onClientConnectedCb;
     StrCb    onNetworkSavedCb;
-    VoidCb   onRebootCb;
+    RebootCb onRebootCb;
 
     void loadNetworksIntoMulti();
     void migrateFromWifiManager();


### PR DESCRIPTION
## Summary

- Add 3-minute captive portal timeout — after expiry the device reboots via `onRebootCb`
- Replace all direct `ESP.restart()` calls in `JaamWifi` with `onRebootCb` callback
- Align reboot delays with old WiFiManager behavior (portal: 5s, reconnect fail: 3s, save: 2s)
- Align connect timeouts with old WiFiManager behavior (initial: 30s, reconnect: 30s)
- Add WiFi hard reset (disconnect → OFF → STA) before each reconnect attempt
- Wire `onRebootCb` to `rebootDevice(ms)` in JaamFusion

## Test plan

- [x] Flash device without saved networks → captive portal opens → wait 3 min → device reboots
- [x] Open captive portal, save network → device reboots after ~4 sec
- [ ] Disconnect WiFi → verify 5 reconnect attempts with full WiFi reset each → device reboots after ~150 sec
- [x] Normal WiFi connect on boot works within 30 sec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примітки до випуску

* **Нові можливості**
  * Додана система переривання з налаштовуваною затримкою для кращого контролю перезавантаження пристрою.
  * Додано автоматичне перезавантаження, якщо портал не завершити протягом 180 секунд.

* **Покращення**
  * Поліпшена логіка переконектування з повним скиданням стану WiFi.
  * Збільшені часові вікна з'єднання до 30 секунд для підвищення стабільності.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->