### PR TITLE
feat: deploy wiki to Docker via SSH

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,9 @@ on:
       - 'wiki/**'
       - 'mkdocs.yml'
       - 'CHANGELOG.md'
+      - 'requirements.txt'
+      - 'deploy/wiki/**'
+      - 'deploy/redeploy_wiki.sh'
       - '.github/workflows/docs.yml'
   pull_request:
     branches: [main, develop]
@@ -16,36 +19,34 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Deploy Wiki
+        uses: appleboy/ssh-action@v1.2.0
         with:
-          fetch-depth: 0
-      
-      - name: Setup Python
-        uses: actions/setup-python@v5
+          host: ${{ secrets.CLOUD_SERVER_IP }}
+          username: ${{ secrets.CLOUD_SERVER_USER }}
+          key: ${{ secrets.CLOUD_SERVER_SSH_KEY }}
+          script: |
+            set -euo pipefail
+            TEMP_DIR=$(mktemp -d)
+            trap 'rm -rf "$TEMP_DIR"' EXIT
+            cd "$TEMP_DIR"
+            git clone --branch ${{ github.ref_name }} https://github.com/${{ github.repository }}.git .
+            bash deploy/redeploy_wiki.sh
+      - name: Clear unused images
+        uses: appleboy/ssh-action@v1.2.0
         with:
-          python-version: 3.x
-          cache: 'pip'
-      
-      - name: Install dependencies
-        run: |
-          pip install mkdocs-material
-          pip install mkdocs-git-revision-date-localized-plugin
-      
-      - name: Configure Git
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
-      
-      - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force --clean --verbose
+          host: ${{ secrets.CLOUD_SERVER_IP }}
+          username: ${{ secrets.CLOUD_SERVER_USER }}
+          key: ${{ secrets.CLOUD_SERVER_SSH_KEY }}
+          script: |
+            docker image prune -f
 
   build:
     runs-on: ubuntu-latest
@@ -53,17 +54,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: 3.x
           cache: 'pip'
-      
+
       - name: Install dependencies
-        run: |
-          pip install mkdocs-material
-          pip install mkdocs-git-revision-date-localized-plugin
-      
+        run: pip install -r requirements.txt
+
       - name: Build documentation
         run: mkdocs build --strict --verbose

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,11 @@ on:
     paths:
       - 'wiki/**'
       - 'mkdocs.yml'
+      - 'CHANGELOG.md'
+      - 'requirements.txt'
+      - 'deploy/wiki/**'
+      - 'deploy/redeploy_wiki.sh'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
     inputs:
       server_choice:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,16 @@ on:
       - 'wiki/**'
       - 'mkdocs.yml'
   workflow_dispatch:
+    inputs:
+      server_choice:
+        type: choice
+        default: 'Server 1'
+        description: Choose server
+        options:
+          - 'Server 1'
+          - 'Server 2'
+
+run-name: Deploy Documentation from '${{ github.ref_name }}' branch
 
 permissions:
   contents: read
@@ -25,13 +35,17 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    env:
+      SERVER_IP: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_IP || secrets.CLOUD_SERVER_IP }}
+      SERVER_USER: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_USER || secrets.CLOUD_SERVER_USER }}
+      SERVER_SSH_KEY: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_SSH_KEY || secrets.CLOUD_SERVER_SSH_KEY }}
     steps:
       - name: Deploy Wiki
         uses: appleboy/ssh-action@v1.2.0
         with:
-          host: ${{ secrets.CLOUD_SERVER_IP }}
-          username: ${{ secrets.CLOUD_SERVER_USER }}
-          key: ${{ secrets.CLOUD_SERVER_SSH_KEY }}
+          host: ${{ env.SERVER_IP }}
+          username: ${{ env.SERVER_USER }}
+          key: ${{ env.SERVER_SSH_KEY }}
           script: |
             set -euo pipefail
             TEMP_DIR=$(mktemp -d)
@@ -42,9 +56,9 @@ jobs:
       - name: Clear unused images
         uses: appleboy/ssh-action@v1.2.0
         with:
-          host: ${{ secrets.CLOUD_SERVER_IP }}
-          username: ${{ secrets.CLOUD_SERVER_USER }}
-          key: ${{ secrets.CLOUD_SERVER_SSH_KEY }}
+          host: ${{ env.SERVER_IP }}
+          username: ${{ env.SERVER_USER }}
+          key: ${{ env.SERVER_SSH_KEY }}
           script: |
             docker image prune -f
 

--- a/deploy/redeploy_wiki.sh
+++ b/deploy/redeploy_wiki.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "JAAM WIKI"
+
+# Build documentation
+echo "Installing Python dependencies..."
+pip3 install -r requirements.txt --quiet
+
+echo "Building documentation..."
+mkdocs build --clean
+
+# Build Docker image
+echo "Building Docker image..."
+docker build -t jaam_wiki -f deploy/wiki/Dockerfile .
+
+# Stop and remove old container
+echo "Stopping old container..."
+docker stop jaam_wiki || true
+docker rm jaam_wiki || true
+
+# Deploy new container
+echo "Deploying new container..."
+docker run --name jaam_wiki \
+    --restart unless-stopped \
+    --network=jaam \
+    -d \
+    jaam_wiki
+
+echo "Container deployed successfully!"

--- a/deploy/wiki/Dockerfile
+++ b/deploy/wiki/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY site/ /usr/share/nginx/html


### PR DESCRIPTION
## Summary

- Додано `deploy/wiki/Dockerfile` — nginx:alpine serving MkDocs static site
- Додано `deploy/redeploy_wiki.sh` — скрипт деплою (pip install → mkdocs build → docker run)
- Оновлено `.github/workflows/docs.yml` — SSH деплой замість GitHub Pages

## Деплой

Контейнер `jaam_wiki` запускається в мережі `jaam`, nginx з ukraine_alarm_map проксіює `info.jaam.net.ua` → `http://jaam_wiki:80`.

## Test plan

- [x] PR build: `mkdocs build --strict` проходить без помилок
- [x] Після мержу: workflow деплоїть контейнер `jaam_wiki` на сервері
- [x] `info.jaam.net.ua` відкривається через nginx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Переведено розгортання wiki на SSH-базований процес із запуском у Docker на віддаленому сервері.
  * Додано скрипт для переіндексації і перезапуску сайту з автоматичним управлінням образами й контейнерами.
  * Розширено тригери документаційної CI/CD та звужено дозволи workflow (зменшено доступ до вмісту).
* **Build**
  * Перенесено встановлення залежностей до requirements.txt і додано окремий крок збірки MkDocs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/J-A-A-M/jaam_fusion/pull/79)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->