### PR TITLE
fix: retry MOS beep interval if startup delayed needToPlaySound check

### DIFF
--- a/src/JaamFusion.cpp
+++ b/src/JaamFusion.cpp
@@ -2712,6 +2712,10 @@ void checkMinuteOfSilence()
             }
         }
     }
+    // if startup delayed the interval setup, retry on each tick until it succeeds
+    if (minuteOfSilence && clockBeepInterval < 0 && needToPlaySound(MIN_OF_SILINCE)) {
+        clockBeepInterval = async.setInterval(playMinOfSilenceSound, 2000);
+    }
 }
 
 void websocketProcess() {


### PR DESCRIPTION
## Problem

When the device boots close to 9:00 AM, `startup=true` or `isFirstDataFetchCompleted=false` at the exact moment the Minute of Silence transition fires. Since `needToPlaySound()` returns `false` during startup, the `setInterval` for the beep is never created. The transition block only runs once (on state change), so the interval is never retried — resulting in no beep for the entire minute. The anthem at the end still plays because by 9:01 startup is complete.

## Fix

Added a late-init check outside the transition block in `checkMinuteOfSilence()`. It runs every second during the minute of silence and sets the beep interval as soon as `needToPlaySound` returns `true`.

## Test plan

- [x] Flash with `TEST_MIN_OF_SILENCE` enabled
- [x] Restart device so it boots during an active MOS window — verify beep starts shortly after startup completes
- [x] Normal boot before MOS — verify beep plays from the start as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примітки до випуску

* **Виправлення помилок**
  * Поліпшена надійність ініціалізації звукового супроводу для режиму мовчання. Система тепер реалізує механізм автоматичного повторення ініціалізації звуків, якщо перша спроба виявилася невдалою. Це забезпечує більш стабільну роботу звукового оповіщення й запобігає проблемам при затримці запуску.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/J-A-A-M/jaam_fusion/pull/80)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->