### PR TITLE
fix: вимикати світлодіоди, не призначені регіону в режимі кастомного маппінгу

### DIFF
--- a/src/JaamAnimation.cpp
+++ b/src/JaamAnimation.cpp
@@ -1193,12 +1193,14 @@ uint32_t AnimationManager::ledActualColor(Adafruit_NeoPixel* strip, uint16_t pos
     uint8_t brightness = 0;
 
     if (strip == strip_main) {
+        // Один раз отримуємо регіони для цього LED — повторно використовуємо нижче
+        uint16_t region_buf[16];
+        int region_count = getRegionsForLedStatic(position, region_buf, 16);
+
         // У режимі кастомного маппінгу світлодіоди, не призначені жодному регіону, вимкнені
-        bool unmappedCustom = false;
-        if (settings->getInt(HARDWARE) == HARDWARE::CUSTOM_MAPPING) {
-            uint16_t region_buf[16];
-            unmappedCustom = (getRegionsForLedStatic(position, region_buf, 16) == 0);
-        }
+        bool unmappedCustom = (settings->getInt(HARDWARE) == HARDWARE::CUSTOM_MAPPING)
+                              && (region_count == 0);
+
         if (isMapOff || unmappedCustom) {
             color = DefaultColors::OFF;
             brightness = 0;
@@ -1223,9 +1225,7 @@ uint32_t AnimationManager::ledActualColor(Adafruit_NeoPixel* strip, uint16_t pos
                         color = result.first;
                         brightness = result.second;
                     } else {
-                        // Немає тривоги — перевіряємо домашній регіон (без heap)
-                        uint16_t region_buf[16];
-                        int region_count = getRegionsForLedStatic(position, region_buf, 16);
+                        // Немає тривоги — перевіряємо домашній регіон (region_buf уже заповнений вище)
                         color = colorFromHex(settings->getString(COLOR_CLEAR));
                         brightness = led.brightnessRelative(settings->getInt(BRIGHTNESS_CLEAR));
                         for (int r = 0; r < region_count; ++r) {

--- a/src/JaamAnimation.cpp
+++ b/src/JaamAnimation.cpp
@@ -1193,7 +1193,13 @@ uint32_t AnimationManager::ledActualColor(Adafruit_NeoPixel* strip, uint16_t pos
     uint8_t brightness = 0;
 
     if (strip == strip_main) {
-        if (isMapOff) {
+        // У режимі кастомного маппінгу світлодіоди, не призначені жодному регіону, вимкнені
+        bool unmappedCustom = false;
+        if (settings->getInt(HARDWARE) == HARDWARE::CUSTOM_MAPPING) {
+            uint16_t region_buf[16];
+            unmappedCustom = (getRegionsForLedStatic(position, region_buf, 16) == 0);
+        }
+        if (isMapOff || unmappedCustom) {
             color = DefaultColors::OFF;
             brightness = 0;
         } else {


### PR DESCRIPTION
## Опис

Коли `HARDWARE` встановлено в `CUSTOM_MAPPING`, світлодіоди, які
користувач не призначив жодному регіону, відображалися кольором
"немає тривоги" (`COLOR_CLEAR`, за замовчуванням зелений) у режимі
`ALERT`, а також відповідними дефолтними кольорами в режимах
`WEATHER`, `FLAG`, `LAMP` і `RANDOM_COLORS`. Візуально вони виглядали
як спокійний регіон, а не як невикористаний LED.

## Причина

У `AnimationManager::ledActualColor()` (гілка `strip_main`) гілка
"немає тривоги" безумовно присвоювала `COLOR_CLEAR`, не перевіряючи
чи повертає `getRegionsForLedStatic()` нуль регіонів для цього LED.

## Виправлення

У гілці `strip_main` функції `ledActualColor()`, перед входом у
`switch` режимів карти, один раз перевіряємо, чи має LED призначення
до якогось регіону. Якщо `HARDWARE == CUSTOM_MAPPING` і LED не
призначений — встановлюємо `DefaultColors::OFF` з нульовою яскравістю.
Перевірка застосовується однаково до всіх режимів карти; фонова
(`strip_bg`) і сервісна (`strip_service`) стрічки не змінені.

## План тестування

- [x] Чиста збірка для `firmware_esp32s3` та `firmware`
- [x] Прошито на JAAM ESP32-S3 з кастомним маппінгом — непризначені
  LED темні в режимі ALERT, призначені регіони відображаються нормально
- [x] Прошито на JAAM 2.0 з вбудованим маппінгом
  (`HARDWARE != CUSTOM_MAPPING`) — поведінка не змінена
- [x] Перевірено всі режими карти (ALERT, WEATHER, FLAG, LAMP,
  RANDOM_COLORS) — працюють коректно

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Виправлення помилок**
  * У режимі користувацького картографування невмаплені світлодіоди тепер примусово вимикаються та мають нульову яскравість для більш передбачуваної поведінки.

* **Оптимізація**
  * У режимі сповіщень покращено визначення домашнього кольору шляхом повторного використання раніше зібраних даних замість повторних обчислень, зменшуючи зайві обробки.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/J-A-A-M/jaam_fusion/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->