### PR TITLE
ci: build docs inside a multistage Docker image

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,16 +74,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # Full history is required by the git-revision-date-localized plugin;
-          # a shallow clone would emit a warning that --strict turns into a failure.
+          # Full history with all blobs is required by the
+          # git-revision-date-localized plugin: its `git log --follow` needs
+          # historical blobs for rename detection. A partial clone (which
+          # sparse-checkout implicitly enables via blob:none) would make git
+          # try to fetch missing blobs from the promisor remote at build time
+          # and fail against the read-only .git bind mount. So fetch everything
+          # and do not narrow the checkout.
           fetch-depth: 0
-          # Only materialize what the build needs (cone mode still includes
-          # root files like mkdocs.yml / requirements.txt), so the repo's
-          # non-docs code isn't checked out to disk on every PR. deploy/wiki
-          # is required because the build step references its Dockerfile.
-          sparse-checkout: |
-            wiki
-            deploy/wiki
 
       - name: Build documentation (strict)
         run: docker build --build-arg MKDOCS_BUILD_STRICT=true -f deploy/wiki/Dockerfile .

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -84,4 +84,4 @@ jobs:
           fetch-depth: 0
 
       - name: Build documentation (strict)
-        run: docker build --build-arg MKDOCS_BUILD_STRICT=true -f deploy/wiki/Dockerfile .
+        run: docker buildx build --build-arg MKDOCS_BUILD_STRICT=true -f deploy/wiki/Dockerfile .

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,15 +73,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
         with:
-          python-version: 3.x
-          cache: 'pip'
+          # Full history is required by the git-revision-date-localized plugin;
+          # a shallow clone would emit a warning that --strict turns into a failure.
+          fetch-depth: 0
 
-      - name: Install dependencies
-        run: pip install -r requirements.txt
-
-      - name: Build documentation
-        run: mkdocs build --strict --verbose
+      - name: Build documentation (strict)
+        run: docker build --build-arg MKDOCS_BUILD_FLAGS="--clean --strict --verbose" -f deploy/wiki/Dockerfile .

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,7 +72,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Full history with all blobs is required by the
           # git-revision-date-localized plugin: its `git log --follow` needs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -77,10 +77,13 @@ jobs:
           # Full history is required by the git-revision-date-localized plugin;
           # a shallow clone would emit a warning that --strict turns into a failure.
           fetch-depth: 0
-          # Only materialize the docs in the working tree (cone mode still
-          # includes root files like mkdocs.yml / requirements.txt), so the
-          # repo's non-docs code isn't checked out to disk on every PR.
-          sparse-checkout: wiki
+          # Only materialize what the build needs (cone mode still includes
+          # root files like mkdocs.yml / requirements.txt), so the repo's
+          # non-docs code isn't checked out to disk on every PR. deploy/wiki
+          # is required because the build step references its Dockerfile.
+          sparse-checkout: |
+            wiki
+            deploy/wiki
 
       - name: Build documentation (strict)
         run: docker build --build-arg MKDOCS_BUILD_STRICT=true -f deploy/wiki/Dockerfile .

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -77,6 +77,10 @@ jobs:
           # Full history is required by the git-revision-date-localized plugin;
           # a shallow clone would emit a warning that --strict turns into a failure.
           fetch-depth: 0
+          # Only materialize the docs in the working tree (cone mode still
+          # includes root files like mkdocs.yml / requirements.txt), so the
+          # repo's non-docs code isn't checked out to disk on every PR.
+          sparse-checkout: wiki
 
       - name: Build documentation (strict)
         run: docker build --build-arg MKDOCS_BUILD_STRICT=true -f deploy/wiki/Dockerfile .

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -79,4 +79,4 @@ jobs:
           fetch-depth: 0
 
       - name: Build documentation (strict)
-        run: docker build --build-arg MKDOCS_BUILD_FLAGS="--clean --strict --verbose" -f deploy/wiki/Dockerfile .
+        run: docker build --build-arg MKDOCS_BUILD_STRICT=true -f deploy/wiki/Dockerfile .

--- a/deploy/redeploy_wiki.sh
+++ b/deploy/redeploy_wiki.sh
@@ -3,15 +3,7 @@ set -euo pipefail
 
 echo "JAAM WIKI"
 
-# Build documentation
-echo "Installing Python dependencies..."
-python3 -m venv .venv
-.venv/bin/pip install -r requirements.txt --quiet
-
-echo "Building documentation..."
-.venv/bin/mkdocs build --clean
-
-# Build Docker image
+# Build Docker image (docs are built inside the multistage Dockerfile)
 echo "Building Docker image..."
 docker build -t jaam_wiki -f deploy/wiki/Dockerfile .
 

--- a/deploy/redeploy_wiki.sh
+++ b/deploy/redeploy_wiki.sh
@@ -3,9 +3,12 @@ set -euo pipefail
 
 echo "JAAM WIKI"
 
-# Build Docker image (docs are built inside the multistage Dockerfile)
+# Build Docker image (docs are built inside the multistage Dockerfile).
+# --load makes the image available in the local daemon so the docker run
+# below works even when the active buildx builder uses the docker-container
+# driver (which otherwise keeps the result only in the build cache).
 echo "Building Docker image..."
-docker buildx build -t jaam_wiki -f deploy/wiki/Dockerfile .
+docker buildx build --load -t jaam_wiki -f deploy/wiki/Dockerfile .
 
 # Stop and remove old container
 echo "Stopping old container..."

--- a/deploy/redeploy_wiki.sh
+++ b/deploy/redeploy_wiki.sh
@@ -5,7 +5,7 @@ echo "JAAM WIKI"
 
 # Build Docker image (docs are built inside the multistage Dockerfile)
 echo "Building Docker image..."
-docker build -t jaam_wiki -f deploy/wiki/Dockerfile .
+docker buildx build -t jaam_wiki -f deploy/wiki/Dockerfile .
 
 # Stop and remove old container
 echo "Stopping old container..."

--- a/deploy/wiki/Dockerfile
+++ b/deploy/wiki/Dockerfile
@@ -7,12 +7,25 @@ RUN apt-get update \
 
 WORKDIR /build
 
+# Install dependencies first so this layer stays cached unless requirements change
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
-ARG MKDOCS_BUILD_FLAGS="--clean"
-RUN mkdocs build ${MKDOCS_BUILD_FLAGS}
+# Copy only the MkDocs build inputs to keep the build context small
+# . docs_dir is "wiki" and holds all assets/css/js; .git is needed
+# by the git-revision-date-localized plugin to compute per-page dates.
+COPY mkdocs.yml ./
+COPY wiki/ ./wiki/
+COPY .git/ ./.git/
+
+# Toggle strict validation without interpolating untrusted strings into the
+# shell: the arg is only compared, the mkdocs commands themselves are fixed.
+ARG MKDOCS_BUILD_STRICT=false
+RUN if [ "$MKDOCS_BUILD_STRICT" = "true" ]; then \
+        mkdocs build --clean --strict --verbose; \
+    else \
+        mkdocs build --clean; \
+    fi
 
 FROM nginx:alpine
 COPY --from=builder /build/site /usr/share/nginx/html

--- a/deploy/wiki/Dockerfile
+++ b/deploy/wiki/Dockerfile
@@ -22,7 +22,7 @@ COPY wiki/ ./wiki/
 # MKDOCS_BUILD_STRICT is only compared, never interpolated into the command, so
 # a build arg from untrusted CI input cannot inject shell.
 ARG MKDOCS_BUILD_STRICT=false
-RUN --mount=type=bind,source=.git,target=.git \
+RUN --mount=type=bind,source=.git,target=.git,ro \
     if [ "$MKDOCS_BUILD_STRICT" = "true" ]; then \
         mkdocs build --clean --strict --verbose; \
     else \

--- a/deploy/wiki/Dockerfile
+++ b/deploy/wiki/Dockerfile
@@ -1,2 +1,18 @@
+FROM python:3.13-slim AS builder
+
+# git is required by the mkdocs git-revision-date-localized plugin
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+ARG MKDOCS_BUILD_FLAGS="--clean"
+RUN mkdocs build ${MKDOCS_BUILD_FLAGS}
+
 FROM nginx:alpine
-COPY site/ /usr/share/nginx/html
+COPY --from=builder /build/site /usr/share/nginx/html

--- a/deploy/wiki/Dockerfile
+++ b/deploy/wiki/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.13-slim AS builder
+# syntax=docker/dockerfile:1
+FROM python:3.14-slim AS builder
 
 # git is required by the mkdocs git-revision-date-localized plugin
 RUN apt-get update \
@@ -11,17 +12,18 @@ WORKDIR /build
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy only the MkDocs build inputs to keep the build context small
-# . docs_dir is "wiki" and holds all assets/css/js; .git is needed
-# by the git-revision-date-localized plugin to compute per-page dates.
+# Only the MkDocs build inputs. docs_dir is "wiki" and holds all assets/css/js.
 COPY mkdocs.yml ./
 COPY wiki/ ./wiki/
-COPY .git/ ./.git/
 
-# Toggle strict validation without interpolating untrusted strings into the
-# shell: the arg is only compared, the mkdocs commands themselves are fixed.
+# Build the static site. .git is bind-mounted read-only for this step only, so
+# the large (and possibly credential-bearing) history is available to the
+# git-revision-date-localized plugin without ever landing in an image layer.
+# MKDOCS_BUILD_STRICT is only compared, never interpolated into the command, so
+# a build arg from untrusted CI input cannot inject shell.
 ARG MKDOCS_BUILD_STRICT=false
-RUN if [ "$MKDOCS_BUILD_STRICT" = "true" ]; then \
+RUN --mount=type=bind,source=.git,target=.git \
+    if [ "$MKDOCS_BUILD_STRICT" = "true" ]; then \
         mkdocs build --clean --strict --verbose; \
     else \
         mkdocs build --clean; \

--- a/deploy/wiki/Dockerfile.dockerignore
+++ b/deploy/wiki/Dockerfile.dockerignore
@@ -1,0 +1,9 @@
+# Exclude everything, then re-include only the documentation build inputs.
+# .git is kept because the Dockerfile bind-mounts it for the
+# git-revision-date-localized plugin; the bind mount reads from the build
+# context, so excluding .git here would break the build.
+*
+!mkdocs.yml
+!requirements.txt
+!wiki
+!.git

--- a/deploy/wiki/Dockerfile.dockerignore
+++ b/deploy/wiki/Dockerfile.dockerignore
@@ -1,9 +1,0 @@
-# Exclude everything, then re-include only the documentation build inputs.
-# .git is kept because the Dockerfile bind-mounts it for the
-# git-revision-date-localized plugin; the bind mount reads from the build
-# context, so excluding .git here would break the build.
-*
-!mkdocs.yml
-!requirements.txt
-!wiki
-!.git


### PR DESCRIPTION
Move the MkDocs build into a multistage Dockerfile (python:3.13-slim builder, nginx:alpine runtime) instead of running it directly on the deploy host and the PR runner.

Why:
- The host no longer needs Python, a virtualenv, or a per-deploy `pip install`; Docker is now its only build-time dependency. This removes environment drift between hosts and makes the build self-contained and reproducible.
- Pinning the builder to python:3.13-slim aligns the toolchain with the server repo (ukraine_alarm_map) and keeps glibc instead of musl.
- The PR validation job reuses the exact same Dockerfile, so what CI checks is byte-for-byte what gets deployed; there is no second, separately-maintained toolchain to drift out of sync.

Benefits:
- Final image is unchanged: nginx:alpine serving only static files, nothing else leaks in from the builder stage.
- A MKDOCS_BUILD_FLAGS build arg lets deploy stay lenient while the PR build keeps --strict to catch broken docs before merge.
- fetch-depth: 0 on the PR checkout gives the git-revision-date plugin full history, so accurate dates work and --strict does not fail on a shallow-clone warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Оптимізовано процес збірки документації за допомогою контейнеризації Docker для забезпечення більшої консистентності та надійності інфраструктури.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/J-A-A-M/jaam_fusion/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->