### PR TITLE
ci: build docs in CI and deploy static files (alternative to #83)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,9 +6,7 @@ on:
     paths:
       - 'wiki/**'
       - 'mkdocs.yml'
-      - 'CHANGELOG.md'
       - 'requirements.txt'
-      - 'deploy/wiki/**'
       - 'deploy/redeploy_wiki.sh'
       - '.github/workflows/docs.yml'
   pull_request:
@@ -16,9 +14,7 @@ on:
     paths:
       - 'wiki/**'
       - 'mkdocs.yml'
-      - 'CHANGELOG.md'
       - 'requirements.txt'
-      - 'deploy/wiki/**'
       - 'deploy/redeploy_wiki.sh'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
@@ -37,51 +33,52 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    env:
-      SERVER_IP: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_IP || secrets.CLOUD_SERVER_IP }}
-      SERVER_USER: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_USER || secrets.CLOUD_SERVER_USER }}
-      SERVER_SSH_KEY: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_SSH_KEY || secrets.CLOUD_SERVER_SSH_KEY }}
-    steps:
-      - name: Deploy Wiki
-        uses: appleboy/ssh-action@v1.2.0
-        with:
-          host: ${{ env.SERVER_IP }}
-          username: ${{ env.SERVER_USER }}
-          key: ${{ env.SERVER_SSH_KEY }}
-          script: |
-            set -euo pipefail
-            TEMP_DIR=$(mktemp -d)
-            trap 'rm -rf "$TEMP_DIR"' EXIT
-            cd "$TEMP_DIR"
-            git clone --branch ${{ github.ref_name }} https://github.com/${{ github.repository }}.git .
-            bash deploy/redeploy_wiki.sh
-      - name: Clear unused images
-        uses: appleboy/ssh-action@v1.2.0
-        with:
-          host: ${{ env.SERVER_IP }}
-          username: ${{ env.SERVER_USER }}
-          key: ${{ env.SERVER_SSH_KEY }}
-          script: |
-            docker image prune -f
-
   build:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/checkout@v6
         with:
-          python-version: 3.x
-          cache: 'pip'
-
-      - name: Install dependencies
-        run: pip install -r requirements.txt
+          # Full history is required by the git-revision-date-localized plugin
+          # to compute per-page dates.
+          fetch-depth: 0
 
       - name: Build documentation
-        run: mkdocs build --strict --verbose
+        # Build inside the official Material image (mkdocs + git already baked
+        # in); only the git-revision-date plugin needs adding. The repo is
+        # bind-mounted read-write, so the plugin's `git log` works without the
+        # read-only / partial-clone pitfalls of building inside a Dockerfile.
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/docs" \
+            --entrypoint sh \
+            squidfunk/mkdocs-material:9.7.6 \
+            -c 'git config --global --add safe.directory /docs \
+                && pip install --quiet --root-user-action=ignore mkdocs-git-revision-date-localized-plugin \
+                && mkdocs build --clean --strict'
+
+      - name: Deploy site to host
+        # Same job as the build, so site/ is still in the workspace - no
+        # upload/download artifact needed. Only deploy on push / manual
+        # dispatch; on pull_request the build above runs as a --strict check.
+        # A failed build stops the job before this step, so prod is untouched.
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        env:
+          SERVER_IP: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_IP || secrets.CLOUD_SERVER_IP }}
+          SERVER_USER: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_USER || secrets.CLOUD_SERVER_USER }}
+          SERVER_SSH_KEY: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_SSH_KEY || secrets.CLOUD_SERVER_SSH_KEY }}
+          DEPLOY_DIR: /opt/jaam_wiki/site
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SERVER_SSH_KEY" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          ssh-keyscan -H "$SERVER_IP" >> ~/.ssh/known_hosts 2>/dev/null
+
+          ssh -i ~/.ssh/id_deploy "$SERVER_USER@$SERVER_IP" "mkdir -p '$DEPLOY_DIR'"
+
+          rsync -az --delete --delay-updates \
+            -e "ssh -i ~/.ssh/id_deploy" \
+            site/ "$SERVER_USER@$SERVER_IP:$DEPLOY_DIR/"
+
+          ssh -i ~/.ssh/id_deploy "$SERVER_USER@$SERVER_IP" \
+            "bash -s -- '$DEPLOY_DIR'" < deploy/redeploy_wiki.sh

--- a/deploy/redeploy_wiki.sh
+++ b/deploy/redeploy_wiki.sh
@@ -1,31 +1,22 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "JAAM WIKI"
+# Host-side deploy step. The static docs are rsynced to $HTML_DIR by CI;
+# this just (re)creates a stock nginx container that serves them read-only on
+# the jaam network. No build happens on the host.
+HTML_DIR="${1:?usage: redeploy_wiki.sh <html-dir>}"
 
-# Build documentation
-echo "Installing Python dependencies..."
-python3 -m venv .venv
-.venv/bin/pip install -r requirements.txt --quiet
+echo "Serving JAAM WIKI from ${HTML_DIR}"
 
-echo "Building documentation..."
-.venv/bin/mkdocs build --clean
-
-# Build Docker image
-echo "Building Docker image..."
-docker build -t jaam_wiki -f deploy/wiki/Dockerfile .
-
-# Stop and remove old container
-echo "Stopping old container..."
-docker stop jaam_wiki || true
-docker rm jaam_wiki || true
-
-# Deploy new container
-echo "Deploying new container..."
+docker pull nginx:alpine
+docker rm -f jaam_wiki 2>/dev/null || true
 docker run --name jaam_wiki \
     --restart unless-stopped \
     --network=jaam \
-    -d \
-    jaam_wiki
+    -v "${HTML_DIR}:/usr/share/nginx/html:ro" \
+    -d nginx:alpine
 
-echo "Container deployed successfully!"
+# Drop the now-dangling old nginx image left by the pull above.
+docker image prune -f
+
+echo "Container deployed."

--- a/deploy/wiki/Dockerfile
+++ b/deploy/wiki/Dockerfile
@@ -1,2 +1,0 @@
-FROM nginx:alpine
-COPY site/ /usr/share/nginx/html


### PR DESCRIPTION
## Summary

  Alternative approach to #83 for building and deploying the documentation site.

  Instead of building a Docker **image** on the production host (as in #83), this
  builds the **static site in CI** and ships the files to the host, which serves
  them with a stock `nginx:alpine` container.

  Both PRs solve the same original problem — no Python/pip on the host and no
  per-deploy `pip install`. They are **mutually exclusive**; pick one.

  ## What changed

  - **`.github/workflows/docs.yml`** — a single `build` job:
    - Builds the site inside the official `squidfunk/mkdocs-material:9.7.6` image
      (mkdocs + git already baked in) via `docker run -v`, adding only the
      `git-revision-date-localized` plugin, with `mkdocs build --clean --strict`.
    - In the **same job** (so `site/` stays in the workspace — no artifact
      upload/download) rsyncs the built site to the target host and runs the
      host-side serve script. Deploy is gated to `push` / `workflow_dispatch`;
      on `pull_request` the build runs as a `--strict` check only.
  - **`deploy/redeploy_wiki.sh`** — now a host-side script that (re)creates a
    stock `nginx:alpine` container serving the synced dir read-only
    (`-v <dir>:/usr/share/nginx/html:ro`) on the `jaam` network. No build on the host.
  - **Removes** `deploy/wiki/Dockerfile` — no custom image is built.

  ## How it differs from #83

  |                | #83 (image)                                   | This PR (static files)                    |
  |----------------|-----------------------------------------------|-------------------------------------------|
  | Build location | production host, at deploy time               | ephemeral CI runner                       |
  | Build tooling  | custom multistage Dockerfile (`.git` bind mount, `.dockerignore`) | stock `squidfunk/mkdocs-material` image + 1 plugin |
  | Artifact       | nginx image (rebuilt per host)                | static `site/` rsynced to the host        |
  | Host runtime   | runs the baked image                          | stock `nginx:alpine` + volume mount       |

  ## Pros

  - **Resource usage** — the prod host no longer builds anything: no Python, no
    Docker *build*, no repo clone / `.git`. It just receives an rsync delta and
    runs a ~20 MB nginx.
  - **Reproducibility** — built once in a pinned image; the same bytes ship out,
    instead of each host independently rebuilding its own image.
  - **Fault tolerance** — a broken build fails the CI job *before* the deploy
    step, so the previously-synced files keep serving. A bad build never reaches prod.
  - **CI best practice** — the thing that's validated (`--strict` build) is
    exactly the thing deployed.
  - **Simplicity** — drops the entire custom Dockerfile + `.git` bind mount +
    `.dockerignore`, along with the read-only-mount / partial-clone fragility that
    came with it. The writable whole-workspace mount means the git-revision-date
    plugin just works.

  ## Cons / trade-offs vs #83

  - **No image immutability/provenance** — the artifact is a directory on the
    host, not a content-addressed image with a digest. Mitigable with versioned
    release dirs + checksums, but not built in here.
  - **Hand-rolled deploy** — rsync over SSH + a host serve script instead of the
    standardized `docker run <image>`. (#83 plus a registry would give registry
    tooling for free.)
  - **Deploy atomicity** — uses `rsync --delete --delay-updates` and recreates the
    nginx container, so there's a brief (~1 s) blip on deploy. Zero-downtime +
    instant rollback would need release dirs + a `current` symlink (left out to
    keep it simple).
  - **Bind-mount serving caveats** — file ownership and (on SELinux hosts)
    `:z`/`:Z` labels need attention; an image sidesteps that.

  ## Host prerequisites

  - rsync over SSH from the runner uses the existing `CLOUD_SERVER_*` secrets; the
    deploy key must allow rsync (not a forced command). Host key is
    `ssh-keyscan`'d at runtime.
  - `DEPLOY_DIR` defaults to `/opt/jaam_wiki/site` (created by the deploy step);
    change if needed.
  - The `jaam` Docker network must exist on the host (unchanged).

  ## Notes

  - Dropped the `CHANGELOG.md` / `deploy/wiki/**` path triggers — neither is
    consumed by the build (the changelog page only links to GitHub Releases).
    Easy to re-add if `CHANGELOG.md` is later embedded into a page.
  - `git config --global --add safe.directory /docs` is kept as cheap insurance;
    it's technically redundant because the squidfunk image already pre-trusts
    `/docs` in `/etc/gitconfig`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примітки до версії

* **Chores**
  * Оптимізовано процес деплойменту документації через оновлення CI/CD workflow.
  * Перебудовано архітектуру розгортання: збірка документації перенесена в контейнеризоване середовище, а скрипти розгортання спрощені для фокусу лише на управлінні контейнерами.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/J-A-A-M/jaam_fusion/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->