### PR TITLE
ci: build a clean nginx+docs image in CI (hybrid of #83 and #84)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,53 +35,96 @@ run-name: Deploy Documentation from '${{ github.ref_name }}' branch
 
 permissions:
   contents: read
+  # NOTE: Option A (GHCR push/pull) below also requires `packages: write` here.
+  # packages: write
 
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    env:
-      SERVER_IP: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_IP || secrets.CLOUD_SERVER_IP }}
-      SERVER_USER: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_USER || secrets.CLOUD_SERVER_USER }}
-      SERVER_SSH_KEY: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_SSH_KEY || secrets.CLOUD_SERVER_SSH_KEY }}
-    steps:
-      - name: Deploy Wiki
-        uses: appleboy/ssh-action@v1.2.0
-        with:
-          host: ${{ env.SERVER_IP }}
-          username: ${{ env.SERVER_USER }}
-          key: ${{ env.SERVER_SSH_KEY }}
-          script: |
-            set -euo pipefail
-            TEMP_DIR=$(mktemp -d)
-            trap 'rm -rf "$TEMP_DIR"' EXIT
-            cd "$TEMP_DIR"
-            git clone --branch ${{ github.ref_name }} https://github.com/${{ github.repository }}.git .
-            bash deploy/redeploy_wiki.sh
-      - name: Clear unused images
-        uses: appleboy/ssh-action@v1.2.0
-        with:
-          host: ${{ env.SERVER_IP }}
-          username: ${{ env.SERVER_USER }}
-          key: ${{ env.SERVER_SSH_KEY }}
-          script: |
-            docker image prune -f
-
   build:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    env:
+      IMAGE_NAME: jaam_wiki
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/checkout@v6
         with:
-          python-version: 3.x
-          cache: 'pip'
+          # Full history is required by the git-revision-date-localized plugin.
+          fetch-depth: 0
 
-      - name: Install dependencies
-        run: pip install -r requirements.txt
+      - name: Build documentation image
+        # Multistage build: squidfunk/mkdocs-material compiles the site, the
+        # final stage is a clean nginx:alpine holding only the static files.
+        # The `mkdocs build --strict` inside the Dockerfile doubles as PR
+        # validation, so this step runs on pull_request too.
+        run: docker build -t "$IMAGE_NAME:latest" -f deploy/wiki/Dockerfile .
 
-      - name: Build documentation
-        run: mkdocs build --strict --verbose
+      # =================================================================
+      # DEPLOY - pick exactly ONE of the two options below (push / dispatch).
+      # Keep one block uncommented and the other commented out.
+      # =================================================================
+
+      # -----------------------------------------------------------------
+      # OPTION A - GHCR push / pull   (cleaner, but needs one-time setup:
+      #   * uncomment `packages: write` in the top-level `permissions:` block
+      #   * GHCR enabled for the org/repo; if the package is private, the
+      #     target host must `docker login ghcr.io` once)
+      # To use: uncomment this whole block and comment OPTION B.
+      # -----------------------------------------------------------------
+      # - name: Log in to GitHub Container Registry
+      #   if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+      #   run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      #
+      # - name: Push image to GHCR
+      #   if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+      #   run: |
+      #     set -euo pipefail
+      #     REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')   # GHCR path must be lowercase
+      #     IMAGE="ghcr.io/${REPO}/${IMAGE_NAME}"
+      #     docker tag "$IMAGE_NAME:latest" "$IMAGE:latest"
+      #     docker tag "$IMAGE_NAME:latest" "$IMAGE:${{ github.sha }}"
+      #     docker push "$IMAGE:latest"
+      #     docker push "$IMAGE:${{ github.sha }}"
+      #
+      # - name: Pull and (re)create container on host
+      #   if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+      #   env:
+      #     SERVER_IP: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_IP || secrets.CLOUD_SERVER_IP }}
+      #     SERVER_USER: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_USER || secrets.CLOUD_SERVER_USER }}
+      #     SERVER_SSH_KEY: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_SSH_KEY || secrets.CLOUD_SERVER_SSH_KEY }}
+      #   run: |
+      #     set -euo pipefail
+      #     REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+      #     IMAGE="ghcr.io/${REPO}/${IMAGE_NAME}:latest"
+      #     mkdir -p ~/.ssh
+      #     printf '%s\n' "$SERVER_SSH_KEY" > ~/.ssh/id_deploy
+      #     chmod 600 ~/.ssh/id_deploy
+      #     ssh-keyscan -H "$SERVER_IP" >> ~/.ssh/known_hosts 2>/dev/null
+      #     ssh -i ~/.ssh/id_deploy "$SERVER_USER@$SERVER_IP" \
+      #       "docker pull '$IMAGE' && bash -s -- '$IMAGE'" < deploy/redeploy_wiki.sh
+
+      # -----------------------------------------------------------------
+      # OPTION B - docker save / scp / load   (no GitHub configuration
+      #   required; works out of the box). [ACTIVE]
+      # To use OPTION A instead: comment this block and uncomment OPTION A.
+      # -----------------------------------------------------------------
+      - name: Deploy image to host via save / load over SSH
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        env:
+          SERVER_IP: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_IP || secrets.CLOUD_SERVER_IP }}
+          SERVER_USER: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_USER || secrets.CLOUD_SERVER_USER }}
+          SERVER_SSH_KEY: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_SSH_KEY || secrets.CLOUD_SERVER_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          docker save "$IMAGE_NAME:latest" | gzip > jaam_wiki.tar.gz
+
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SERVER_SSH_KEY" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          ssh-keyscan -H "$SERVER_IP" >> ~/.ssh/known_hosts 2>/dev/null
+
+          rsync -az -e "ssh -i ~/.ssh/id_deploy" \
+            jaam_wiki.tar.gz "$SERVER_USER@$SERVER_IP:/tmp/jaam_wiki.tar.gz"
+
+          ssh -i ~/.ssh/id_deploy "$SERVER_USER@$SERVER_IP" \
+            "docker load -i /tmp/jaam_wiki.tar.gz \
+             && rm -f /tmp/jaam_wiki.tar.gz \
+             && bash -s -- '$IMAGE_NAME:latest'" < deploy/redeploy_wiki.sh

--- a/deploy/redeploy_wiki.sh
+++ b/deploy/redeploy_wiki.sh
@@ -1,31 +1,21 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "JAAM WIKI"
+# Host-side deploy step: (re)create the wiki container from a prebuilt image.
+# CI builds a clean nginx + static-files image and delivers it to this host
+# (either via GHCR pull or `docker load`); this just swaps the running
+# container over to it. No build happens on the host.
+IMAGE="${1:?usage: redeploy_wiki.sh <image-ref>}"
 
-# Build documentation
-echo "Installing Python dependencies..."
-python3 -m venv .venv
-.venv/bin/pip install -r requirements.txt --quiet
+echo "Deploying JAAM WIKI from image ${IMAGE}"
 
-echo "Building documentation..."
-.venv/bin/mkdocs build --clean
-
-# Build Docker image
-echo "Building Docker image..."
-docker build -t jaam_wiki -f deploy/wiki/Dockerfile .
-
-# Stop and remove old container
-echo "Stopping old container..."
-docker stop jaam_wiki || true
-docker rm jaam_wiki || true
-
-# Deploy new container
-echo "Deploying new container..."
+docker rm -f jaam_wiki 2>/dev/null || true
 docker run --name jaam_wiki \
     --restart unless-stopped \
     --network=jaam \
-    -d \
-    jaam_wiki
+    -d "$IMAGE"
 
-echo "Container deployed successfully!"
+# Drop the now-dangling previous image.
+docker image prune -f
+
+echo "Container deployed."

--- a/deploy/wiki/Dockerfile
+++ b/deploy/wiki/Dockerfile
@@ -1,2 +1,21 @@
+# Stage 1 - build the static site.
+# Material for MkDocs already ships mkdocs + git, so we only add the
+# revision-date plugin on top.
+FROM squidfunk/mkdocs-material:9.7.6 AS builder
+
+RUN pip install --no-cache-dir --root-user-action=ignore \
+        mkdocs-git-revision-date-localized-plugin
+
+WORKDIR /docs
+
+# Copy the whole repo so the git-revision-date-localized plugin sees the full
+# history (.git). COPY makes the tree root-owned, matching the build user, so
+# no git safe.directory tweak is needed (and this image pre-trusts /docs anyway).
+COPY . .
+
+RUN mkdocs build --clean --strict
+
+# Stage 2 - serve the built site from a clean nginx image. Nothing from the
+# builder stage (mkdocs, git, .git, sources) ends up here - only static files.
 FROM nginx:alpine
-COPY site/ /usr/share/nginx/html
+COPY --from=builder /docs/site /usr/share/nginx/html


### PR DESCRIPTION
  ## Summary

  A third approach for building/deploying the docs, combining the strengths of #83 and #84:

  - like **#83**, the artifact is a self-contained `nginx:alpine` image with the static files baked in;
  - like **#84**, that image is built **once in CI**, not on the production host.

  The result: an immutable, content-addressed image (digest, atomic `docker run` swap, trivial rollback) **and** a prod host that needs no Python, no Docker *build*, and no repo clone. All three PRs (#83, #84, this) are **mutually exclusive** — pick one.

  ## What changed

  - **`deploy/wiki/Dockerfile`** — multistage:
    - *Stage 1* builds the site in `squidfunk/mkdocs-material:9.7.6` (mkdocs + git already baked in); only the `git-revision-date-localized` plugin is added, then `mkdocs build --clean --strict`. `COPY` makes the tree root-owned, so no `safe.directory` workaround is needed.
    - *Stage 2* is a clean `nginx:alpine` with only `COPY --from=builder /docs/site`. No mkdocs, git, `.git`, or sources reach the final image.
  - **`.github/workflows/docs.yml`** — a single `build` job builds the image on the CI runner (the `--strict` Dockerfile build doubles as PR validation), then delivers it to the host via **one of two interchangeable blocks**; exactly one is uncommented:
    - **Option A — GHCR push/pull** *(commented)*: cleaner and gives registry tooling, but needs one-time setup (`packages: write` permission + GHCR enabled; if the package is private the host must `docker login ghcr.io`).
    - **Option B — `docker save` → rsync → `docker load`** *(active)*: needs **no GitHub configuration**, so it works out of the box.
  - **`deploy/redeploy_wiki.sh`** — now a host-side step that just (re)creates the `jaam_wiki` container from the delivered image ref. No build on the host.

  ## How it relates to #83 and #84

  |                | #83 (image, build on host) | #84 (static files, build in CI) | This PR (image, build in CI) |
  |----------------|---------------------------|----------------------------------|------------------------------|
  | Build location | production host            | CI runner                        | CI runner                    |
  | Artifact       | nginx image (per host)     | static `site/` dir               | nginx image (built once)     |
  | Immutable/digest | image, but rebuilt per host | no (mutable dir)               | **yes** (one image, digest)  |
  | Host runtime   | runs baked image           | stock nginx + volume mount       | runs delivered image         |
  | Prod build deps | Python/Docker build/.git  | none                             | none                         |

  ## Pros

  - **Immutable, content-addressed artifact** (vs #84): a single image with a digest, atomic `docker run` swap, and easy rollback (prior tag / saved image).
  - **No build on prod** (vs #83): build cost, Python, Docker build, and `.git` all move to the ephemeral CI runner.
  - **Validated == deployed**: the same image that passed `--strict` in CI is the one that ships ("build once").
  - **Clean image**: multistage discards the builder; final image is nginx + static files only.
  - **No #83-style fragility**: the git-revision-date plugin runs against a full, writable `COPY` in CI — none of the read-only-mount / partial-clone issues that #83 hit.

  ## Cons / trade-offs

  - **Two delivery paths to maintain** (one stays commented).
  - **Option A needs GitHub setup** (`packages: write`, GHCR enabled, host login for a private package).
  - **Option B ships the whole image** (~50 MB gzip'd) on every deploy, vs #84's rsync delta of only changed files — more bytes per deploy for small edits.
  - **Brief recreate blip** on deploy (container is swapped), like #83.

  ## Host prerequisites

  - The `jaam` Docker network must exist (unchanged).
  - **Option B (active):** the image tar is rsync'd over SSH using the existing `CLOUD_SERVER_*` secrets; the host needs `/tmp` space for the transfer.
  - **Option A:** enable GHCR + `packages: write`; for a private package the host must `docker login ghcr.io` once.

  ## Choosing the delivery method

  Default is **Option B** (zero config). To switch to GHCR push/pull, uncomment Option A (and `packages: write` in `permissions:`) and comment Option B — a single block swap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примітки до випуску

* **Chores**
  * Оптимізовано процес розгортання документації через переробку GitHub Actions workflow та Docker multi-stage build для підвищення ефективності.
  * Оновлено скрипт розгортання для роботи з попередньо зібраними образами.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/J-A-A-M/jaam_fusion/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->