### PR TITLE
fix: add hysteresis to sensor-based brightness switching

### DIFF
--- a/src/JaamFusion.cpp
+++ b/src/JaamFusion.cpp
@@ -1955,16 +1955,23 @@ uint8_t getCurrentBrightnes() {
     // режим яскравості 2: використовувати денну або нічну яскравість залежно від рівня освітлення (якщо є датчик освітлення)
     if (settings.getInt(BRIGHTNESS_MODE) == 2 && lightSensor.isLightSensorAvailable()) {
         float lightLevel = lightSensor.getLightLevel();
-        int threshold = settings.getInt(NIGHT_MODE_LIGHT_THRESHOLD);
-        // Гістерезис відносно порогу, щоб дрейф показань сенсора біля межі не смикав яскравість туди-сюди;
-        // мінімум в 1 люкс окремо, бо поріг може бути виставлений дуже низьким
-        int margin = max(1, threshold / 5);
+        // Захист від від'ємного порогу (може бути збережений в обхід валідації налаштувань напряму через API)
+        int threshold = max(0, settings.getInt(NIGHT_MODE_LIGHT_THRESHOLD));
+        // Гістерезис відносно порогу, щоб дрейф показань сенсора біля межі не смикав яскравість туди-сюди.
+        // Запас не повинен перевищувати сам поріг, інакше нижня межа завжди зʼїжджає в 0 і низький поріг стає недосяжним
+        int margin = threshold > 0 ? max(1, threshold / 5) : 0;
+        if (margin >= threshold) margin = max(0, threshold - 1);
         int lowThreshold = max(0, threshold - margin);
         int highThreshold = threshold + margin;
         static bool sensorNightActive = false;
+        static bool sensorNightActiveInitialized = false;
         // Визначаємо день/ніч за рівнем освітлення
         if (!isnan(lightLevel)) {
-            if (sensorNightActive) {
+            if (!sensorNightActiveInitialized) {
+                // При першому валідному вимірі (старт пристрою або перехід у цей режим) визначаємо стан без гістерезису
+                sensorNightActive = lightLevel < threshold;
+                sensorNightActiveInitialized = true;
+            } else if (sensorNightActive) {
                 if (lightLevel > highThreshold) sensorNightActive = false;
             } else {
                 if (lightLevel < lowThreshold) sensorNightActive = true;

--- a/src/JaamFusion.cpp
+++ b/src/JaamFusion.cpp
@@ -1956,9 +1956,20 @@ uint8_t getCurrentBrightnes() {
     if (settings.getInt(BRIGHTNESS_MODE) == 2 && lightSensor.isLightSensorAvailable()) {
         float lightLevel = lightSensor.getLightLevel();
         int threshold = settings.getInt(NIGHT_MODE_LIGHT_THRESHOLD);
+        // Гістерезис відносно порогу, щоб дрейф показань сенсора біля межі не смикав яскравість туди-сюди;
+        // мінімум в 1 люкс окремо, бо поріг може бути виставлений дуже низьким
+        int margin = max(1, threshold / 5);
+        int lowThreshold = max(0, threshold - margin);
+        int highThreshold = threshold + margin;
+        static bool sensorNightActive = false;
         // Визначаємо день/ніч за рівнем освітлення
         if (!isnan(lightLevel)) {
-            return lightLevel < threshold ? settings.getInt(BRIGHTNESS_NIGHT) : settings.getInt(BRIGHTNESS_DAY);
+            if (sensorNightActive) {
+                if (lightLevel > highThreshold) sensorNightActive = false;
+            } else {
+                if (lightLevel < lowThreshold) sensorNightActive = true;
+            }
+            return sensorNightActive ? settings.getInt(BRIGHTNESS_NIGHT) : settings.getInt(BRIGHTNESS_DAY);
         }
     }
     // За замовчуванням повертаємо основну яскравість


### PR DESCRIPTION
## Summary
- Adds a Schmitt-trigger style hysteresis band around `NIGHT_MODE_LIGHT_THRESHOLD` in `getCurrentBrightnes()` for the light-sensor auto-brightness mode (`BRIGHTNESS_MODE == 2`).
- Margin is proportional to the configured threshold (~20%, min 1 lux), so it stays meaningful even when the threshold is set low.
- Without this, small sensor drift right at the threshold could flip day/night brightness back and forth repeatedly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Виправлення**
  * Покращено визначення денного та нічного режимів за даними датчика освітлення.
  * Додано гістерезис, щоб запобігати частому перемиканню режимів при коливаннях освітленості біля порогового значення.
  * Покращено обробку некоректних показників датчика.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->